### PR TITLE
Fix for issue #14 (add support for subdomain IPFS URLs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The IPFS gateway toolkit currently contains the following functions:
   - `https://example-gateway.com/ipfs/CID`
   - `https://example-gateway.com/ipfs/CID/exampleFile.json`
   - `https://example-gateway.com/ipns/CID`
+  - `https://CID.ipfs.example-gateway.com`
+  - `https://CID.ipfs.example-gateway.com/exampleFile.json`
 
 #### Response
 
@@ -75,6 +77,8 @@ The IPFS gateway toolkit currently contains the following functions:
   - `https://example-gateway.com/ipfs/CID`
   - `https://example-gateway.com/ipfs/CID/exampleFile.json`
   - `https://example-gateway.com/ipns/CID`
+  - `https://CID.ipfs.example-gateway.com`
+  - `https://CID.ipfs.example-gateway.com/exampleFile.json`
 - `desiredGatewayPrefix` - The desired gateway you want to convert your source URL to. A few examples of this would be:
   - `https://mygateway.mypinata.cloud`
   - `https://ipfs.io`

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 const isIPFS = require("is-ipfs");
-const http = require('url');
 
 class IpfsGatewayTools {
   constructor() {}
@@ -57,6 +56,7 @@ class IpfsGatewayTools {
     //case 4 - the subdomain https://cid.ipfs.<gateway-host>.tld/path/to/resource path (eg. https://cid.ipfs.dweb.link)
     if (sourceUrl.includes(`https://${results.cid}.ipfs.`)) {
       let pathname = new URL(sourceUrl).pathname;
+      if (pathname == "/") pathname = "";
       return `${desiredGatewayPrefix}/ipfs/${results.cid}${pathname}`
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const isIPFS = require("is-ipfs");
+const http = require('url');
 
 class IpfsGatewayTools {
   constructor() {}
@@ -51,6 +52,12 @@ class IpfsGatewayTools {
     //case 3 - the /ipns/cid path
     if (sourceUrl.includes(`/ipns/${results.cid}`)) {
       return `${desiredGatewayPrefix}/ipns/${results.cid}${splitUrl[1]}`;
+    }
+
+    //case 4 - the subdomain https://cid.ipfs.<gateway-host>.tld/path/to/resource path (eg. https://cid.ipfs.dweb.link)
+    if (sourceUrl.includes(`https://${results.cid}.ipfs.`)) {
+      let pathname = new URL(sourceUrl).pathname;
+      return `${desiredGatewayPrefix}/ipfs/${results.cid}${pathname}`
     }
 
     //this is the fallback if no supported patterns are provided

--- a/tests/test.js
+++ b/tests/test.js
@@ -30,11 +30,29 @@ describe("containsCID function testing", () => {
       )
     ).toEqual(expectedResult);
   });
+  test("returns true if base32 CID", () => {
+    const CIDToLookFor = "bafybeigeweglu3c2hgyuobwuhugxzp3xgea5fdtht4yg4e4mcdfz3hx7hy";
+    const expectedResult = {
+      containsCid: true,
+      cid: CIDToLookFor,
+    };
+    expect(ipfsGatewayTools.containsCID(`ipfs://${CIDToLookFor}`)).toEqual(
+      expectedResult
+    );
+
+    expect(
+      ipfsGatewayTools.containsCID(
+        `https://ipfs.io/ipfs/${CIDToLookFor}?filename=IMG_20210917_135500_HDR`
+      )
+    ).toEqual(expectedResult);
+  });
 });
 
 describe("convertToDesiredGateway function testing", () => {
   const desiredGatewayPrefix = "https://gateway.pinata.cloud";
   const theCID = "QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o";
+
+  const base32CID = "bafybeigeweglu3c2hgyuobwuhugxzp3xgea5fdtht4yg4e4mcdfz3hx7hy";
   test("throws if url does not contain a CID", () => {
     expect(() => {
       ipfsGatewayTools.convertToDesiredGateway(`ipfs://testing`);
@@ -76,5 +94,19 @@ describe("convertToDesiredGateway function testing", () => {
       desiredGatewayPrefix
     );
     expect(results).toEqual(`${desiredGatewayPrefix}/ipfs/${theCID}/test.json`);
+  });
+  test("correctly returns subdomain style path", () => {
+    const results = ipfsGatewayTools.convertToDesiredGateway(
+      `https://${base32CID}.ipfs.dweb.link`,
+      desiredGatewayPrefix
+    );
+    expect(results).toEqual(`${desiredGatewayPrefix}/ipfs/${base32CID}`);
+  });
+  test("correctly returns subdomain style path with directory path", () => {
+    const results = ipfsGatewayTools.convertToDesiredGateway(
+      `https://${base32CID}.ipfs.dweb.link/test.json`,
+      desiredGatewayPrefix
+    );
+    expect(results).toEqual(`${desiredGatewayPrefix}/ipfs/${base32CID}/test.json`);
   });
 });


### PR DESCRIPTION
Add support for subdomain IPFS URLs.

### Subdomain Format 

` https://cid.ipfs.<gateway-host>.tld/path/to/resource`

### Example
https://bafybeigeweglu3c2hgyuobwuhugxzp3xgea5fdtht4yg4e4mcdfz3hx7hy.ipfs.dweb.link/5406.png